### PR TITLE
AMP-96460 add s3 endpoint as a new param

### DIFF
--- a/unload_databricks_data_to_s3.py
+++ b/unload_databricks_data_to_s3.py
@@ -78,7 +78,7 @@ def export_meta_data(event_count: int, partition_count: int):
 
 
 
-# Example: python3 ./unload_databricks_data_to_s3.py --table_versions_map test_category_do_not_delete_or_modify.canary_tests.employee=16-16 --data_type EVENT --sql "select unix_millis(current_timestamp()) as time, id as user_id, \"databricks_import_canary_test_event\" as event_type, named_struct('name', name, 'home', home, 'age', age, 'income', income) as user_properties, named_struct('group_type1', ARRAY(\"group_A\", \"group_B\")) as groups, named_struct('group_property', \"group_property_value\") as group_properties from test_category_do_not_delete_or_modify.canary_tests.employee" --secret_scope amplitude_databricks_import --secret_key_name_for_aws_access_key source_destination_55_batch_1350266533_aws_access_key --secret_key_name_for_aws_secret_key source_destination_55_batch_1350266533_aws_secret_key --secret_key_name_for_aws_session_token source_destination_55_batch_1350266533_aws_session_token --s3_region us-west-2 --s3_path s3a://com-amplitude-falcon-stag2/databricks_import/unloaded_data/source_destination_55/batch_1350266533/
+# Example: python3 ./unload_databricks_data_to_s3.py --table_versions_map test_category_do_not_delete_or_modify.canary_tests.employee=16-16 --data_type EVENT --sql "select unix_millis(current_timestamp()) as time, id as user_id, \"databricks_import_canary_test_event\" as event_type, named_struct('name', name, 'home', home, 'age', age, 'income', income) as user_properties, named_struct('group_type1', ARRAY(\"group_A\", \"group_B\")) as groups, named_struct('group_property', \"group_property_value\") as group_properties from test_category_do_not_delete_or_modify.canary_tests.employee" --secret_scope amplitude_databricks_import --secret_key_name_for_aws_access_key source_destination_55_batch_1350266533_aws_access_key --secret_key_name_for_aws_secret_key source_destination_55_batch_1350266533_aws_secret_key --secret_key_name_for_aws_session_token source_destination_55_batch_1350266533_aws_session_token --s3_region us-west-2 --s3_endpoint s3.us-west-2.amazonaws.com --s3_path s3a://com-amplitude-falcon-stag2/databricks_import/unloaded_data/source_destination_55/batch_1350266533/
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='unload data from databricks using SparkPython')
     # replace 'required=True' with 'nargs='?', default=None' to make it optional.
@@ -99,7 +99,8 @@ if __name__ == '__main__':
                         help="databricks secret key name of aws_secret_key")
     parser.add_argument("--secret_key_name_for_aws_session_token", required=True,
                         help="databricks secret key name of aws_session_token")
-    parser.add_argument("--s3_region", required=True, help="s3 region")
+    parser.add_argument("--s3_region", nargs='?', default=None, help="s3 region")
+    parser.add_argument("--s3_endpoint", nargs='?', default=None, help="s3 endpoint")
     parser.add_argument("--s3_path", required=True, help="s3 path where data will be written into")
     parser.add_argument("--max_records_per_file", help="max records per output file", nargs='?', type=int, default=MAX_RECORDS_PER_OUTPUT_FILE, const=MAX_RECORDS_PER_OUTPUT_FILE)
 
@@ -114,7 +115,10 @@ if __name__ == '__main__':
     spark.conf.set("fs.s3a.access.key", aws_access_key)
     spark.conf.set("fs.s3a.secret.key", aws_secret_key)
     spark.conf.set("fs.s3a.session.token", aws_session_token)
-    spark.conf.set("fs.s3a.endpoint.region", args.s3_region)
+    if args.s3_region is not None:
+        spark.conf.set("fs.s3a.endpoint.region", args.s3_region)
+    if args.s3_endpoint is not None:
+        spark.conf.set("fs.s3a.endpoint", args.s3_endpoint)
 
     sql: str = args.sql
 


### PR DESCRIPTION
We have observed exception where spark couldn't write data to s3 due to wrong region setup. So apparently `fs.s3a.endpoint.region` is not working as expected. Changing it to `fs.s3a.endpoint`. Have tested it with SEEK and it works.

```
com.amazonaws.services.s3.model.AmazonS3Exception: The bucket is in this region: us-west-2. Please use this region to retry the request (Service: Amazon S3; Status Code: 301; Error Code: 301 Moved Permanently; Request ID: TA5DB853QMP226MJ; S3 Extended Request ID: 
```