### PR TITLE
AMP-96980 Add event row mutation support

### DIFF
--- a/test/unload_databricks_data_to_s3_tests.py
+++ b/test/unload_databricks_data_to_s3_tests.py
@@ -1,6 +1,8 @@
 import unittest
 from unload_databricks_data_to_s3 import parse_table_versions_map_arg, build_sql_to_query_table_of_version, \
-    build_sql_to_query_table_between_versions, get_partition_count
+    build_sql_to_query_table_between_versions, get_partition_count, normalize_sql_query, \
+    determine_first_table_name_in_sql, copy_and_inject_cdf_metadata_column_names, \
+    determine_id_column_name_for_mutation_row_type, generate_sql_to_unload_mutation_data
 
 
 class TestStringMethods(unittest.TestCase):
@@ -26,3 +28,136 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(1, get_partition_count(1, 2))
         self.assertEqual(1, get_partition_count(2, 2))
         self.assertEqual(2, get_partition_count(3, 2))
+
+    def test_normalize_sql_query(self):
+        input_query = """
+        SELECT *
+            FROM   
+            table1  
+        WHERE  
+  
+            id = 10
+   
+        """
+        expected_output = "SELECT * FROM table1 WHERE id = 10"
+        self.assertEqual(expected_output, normalize_sql_query(input_query))
+
+    def test_determine_first_table_name_in_sql(self):
+        sql_query = normalize_sql_query(
+            "SELECT * FROM table1 JOIN table2 ON table1.id = table2.id WHERE table1.id = 10")
+        table_names = {"table2", "table1"}
+        expected_output = "table1"
+        self.assertEqual(expected_output, determine_first_table_name_in_sql(sql_query, table_names))
+
+        sql_query = normalize_sql_query(
+            "SELECT * FROM table2 JOIN table1 ON table2.id = table1.id WHERE table2.id = 10")
+        expected_output = "table2"
+        self.assertEqual(expected_output, determine_first_table_name_in_sql(sql_query, table_names))
+
+        sql_query = normalize_sql_query("SELECT * FROM table1")
+        expected_output = "table1"
+        self.assertEqual(expected_output, determine_first_table_name_in_sql(sql_query, table_names))
+
+    def test_copy_and_inject_cdf_metadata_column_names(self):
+        sql_query = normalize_sql_query("SELECT * FROM table1")
+        expected_output = "SELECT _commit_version, _commit_timestamp, _change_type, * FROM table1"
+        self.assertEqual(expected_output, copy_and_inject_cdf_metadata_column_names(sql_query))
+
+        sql_query = normalize_sql_query("select * FROM table1")
+        expected_output = "SELECT _commit_version, _commit_timestamp, _change_type, * FROM table1"
+        self.assertEqual(expected_output, copy_and_inject_cdf_metadata_column_names(sql_query))
+
+        sql_query = normalize_sql_query("sElEct * FROM table1")
+        expected_output = "SELECT _commit_version, _commit_timestamp, _change_type, * FROM table1"
+        self.assertEqual(expected_output, copy_and_inject_cdf_metadata_column_names(sql_query))
+
+        sql_query = normalize_sql_query("SELECT * FROM table1 JOIN (SELECT * FROM table2) ON table1.id = table2.id")
+        expected_output = ("SELECT _commit_version, _commit_timestamp, _change_type, * FROM table1 "
+                           "JOIN (SELECT * FROM table2) ON table1.id = table2.id")
+        self.assertEqual(expected_output, copy_and_inject_cdf_metadata_column_names(sql_query))
+
+        sql_query = normalize_sql_query("SELECT id, name FROM table1")
+        expected_output = "SELECT _commit_version, _commit_timestamp, _change_type, id, name FROM table1"
+        self.assertEqual(expected_output, copy_and_inject_cdf_metadata_column_names(sql_query))
+
+    def test_determine_id_column_name_for_mutation_row_type(self):
+        self.assertEqual('insert_id', determine_id_column_name_for_mutation_row_type('http_api_event_json'))
+        with self.assertRaises(NotImplementedError):
+            determine_id_column_name_for_mutation_row_type('http_api_user_json')
+        with self.assertRaises(NotImplementedError):
+            determine_id_column_name_for_mutation_row_type('http_api_group_json')
+        with self.assertRaises(ValueError):
+            determine_id_column_name_for_mutation_row_type('unknown')
+
+    def test_generate_sql_to_unload_mutation_data(self):
+        sql_query = normalize_sql_query("SELECT id as insert_id, name FROM table1")
+        mutation_row_type = "http_api_event_json"
+        is_initial_sync = True
+        expected_output = """
+          SELECT
+            STRUCT(STRUCT(*) AS current_version) AS data,
+            'insert' as mutation_type,
+            'http_api_event_json' AS data_type,
+            UUID() as mutation_insert_id,
+            unix_timestamp() * 1000 as mutation_time_ms
+          FROM (SELECT id as insert_id, name FROM table1)
+        """
+        self.assertEqual(normalize_sql_query(expected_output),
+                         normalize_sql_query(generate_sql_to_unload_mutation_data(
+                             sql_query, mutation_row_type, is_initial_sync)))
+
+        sql_query = normalize_sql_query("SELECT id as insert_id, name FROM table1")
+        mutation_row_type = "http_api_event_json"
+        is_initial_sync = False
+        expected_output = """
+          WITH CdfData AS (
+            SELECT _commit_version, _commit_timestamp, _change_type, id as insert_id, name FROM table1
+          ),
+          FormattedChanges AS (
+            SELECT STRUCT(* except(_change_type, _commit_version, _commit_timestamp)) AS data, _change_type, _commit_version, _commit_timestamp FROM CdfData
+          ),
+          Combined AS (
+            SELECT
+              STRUCT(
+                CASE WHEN c1._change_type = 'update_postimage' THEN c1.data ELSE c2.data END AS current_version,
+                CASE WHEN c1._change_type = 'update_preimage' THEN c1.data ELSE c2.data END AS previous_version
+              ) AS data,
+              'update' as _change_type,
+              c1._commit_timestamp,
+              c1._commit_version
+            FROM FormattedChanges c1
+            LEFT JOIN FormattedChanges c2 ON c1._commit_version = c2._commit_version AND c1._commit_timestamp = c2._commit_timestamp AND c1._change_type <> c2._change_type AND c1.data.insert_id = c2.data.insert_id
+            WHERE c1._change_type IN ('update_postimage', 'update_preimage') AND c2._change_type IN ('update_postimage', 'update_preimage')
+
+            UNION ALL
+
+            SELECT
+              STRUCT(
+                c1.data AS current_version,
+                null AS previous_version
+              ) as data,
+              c1._change_type,
+              c1._commit_timestamp,
+              c1._commit_version
+            FROM FormattedChanges c1
+            WHERE c1._change_type NOT IN ('update_postimage', 'update_preimage')
+          ),
+          DistinctData AS (
+            SELECT DISTINCT
+              data as data,
+              _change_type,
+              _commit_timestamp,
+              _commit_version
+            FROM Combined
+          )
+          SELECT
+            data,
+            _change_type as mutation_type,
+            'http_api_event_json' AS data_type,
+            UUID() as mutation_insert_id,
+            unix_timestamp(_commit_timestamp) * 1000 as mutation_time_ms
+          FROM DistinctData
+        """
+        self.assertEqual(normalize_sql_query(expected_output),
+                         normalize_sql_query(generate_sql_to_unload_mutation_data(
+                             sql_query, mutation_row_type, is_initial_sync)))

--- a/unload_databricks_data_to_s3.py
+++ b/unload_databricks_data_to_s3.py
@@ -1,6 +1,7 @@
 import argparse
 import collections
 import math
+import re
 import time
 
 from pyspark.sql import SparkSession
@@ -105,7 +106,10 @@ def copy_and_inject_cdf_metadata_column_names(normalized_sql: str) -> str:
     :return: copy of the SQL query with CDF metadata column names injected into the SELECT clause
     """
     # Inject CDF metadata column names into the first SELECT clause
-    return normalized_sql.replace("select ", "select _commit_version, _commit_timestamp, _change_type, ", 1)
+    # Uses regex to replace the first occurrence of "select". The re.IGNORECASE flag is used to make the pattern
+    # case-insensitive
+    pattern = re.compile("select", re.IGNORECASE)
+    return pattern.sub("SELECT _commit_version, _commit_timestamp, _change_type,", normalized_sql, count=1)
 
 
 def determine_id_column_name_for_mutation_row_type(mutation_row_type: str) -> str:


### PR DESCRIPTION
## Description

Adds support for unloading mutation data for event import. 

Currently, limited only to support of a single delta table, which is supposed to be the first one appeared in the SQL query provided by the customer

Follows [CargoRowMutation](https://github.com/amplitude/nova/blob/master/src/main/java/com/amplitude/cargo/rowmutations/CargoRowMutation.java#L37) format

## Testing
- [x] Unit
- [x] Manual testing through DataBricks runbook (`Leon-DataBricks-to-S3-unload-test` in AWS DataBricks account)

Testing Output Example
<details><summary>Initial Sync</summary>
<p>

```
{
    "data":
    {
        "current_version":
        {
            "insert_id": 1,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 11,
            "event_type": "new_event_type"
        }
    },
    "mutation_type": "insert",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "8ad60237-ea1e-4f15-9e7f-cec2d08d7a78",
    "mutation_time_ms": 1712097674000
}
{
    "data":
    {
        "current_version":
        {
            "insert_id": 3,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 13,
            "event_type": "new_event_type"
        }
    },
    "mutation_type": "insert",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "cb3d3a2f-a233-447b-aebe-58fb88145ff3",
    "mutation_time_ms": 1712097674000
}
{
    "data":
    {
        "current_version":
        {
            "insert_id": 4,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 14,
            "event_type": "event4"
        }
    },
    "mutation_type": "insert",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "aa88ebe8-aac8-41ba-9070-c512a1d4b193",
    "mutation_time_ms": 1712097674000
}
```

</p>
</details> 

<details><summary>Continuous Sync</summary>
<p>

```
{
    "data":
    {
        "current_version":
        {
            "insert_id": 1,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 11,
            "event_type": "new_event_type"
        },
        "previous_version":
        {
            "insert_id": 1,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 11,
            "event_type": "event1"
        }
    },
    "mutation_type": "update",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "88311c40-0783-417b-9aa7-18a9805c7422",
    "mutation_time_ms": 1712005735000
}
{
    "data":
    {
        "current_version":
        {
            "insert_id": 3,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 13,
            "event_type": "new_event_type"
        },
        "previous_version":
        {
            "insert_id": 3,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 13,
            "event_type": "event3"
        }
    },
    "mutation_type": "update",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "aadc92fd-7cab-48f0-8a1e-94996162ddd8",
    "mutation_time_ms": 1712005735000
}
{
    "data":
    {
        "current_version":
        {
            "insert_id": 3,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 13,
            "event_type": "event3"
        }
    },
    "mutation_type": "insert",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "060efe4a-0148-4479-b8b7-4d46dde4654c",
    "mutation_time_ms": 1712005708000
}
{
    "data":
    {
        "current_version":
        {
            "insert_id": 4,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 14,
            "event_type": "event4"
        }
    },
    "mutation_type": "insert",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "66fddf62-6182-41f5-a5b5-54699699dcdc",
    "mutation_time_ms": 1712005708000
}
{
    "data":
    {
        "current_version":
        {
            "insert_id": 2,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 12,
            "event_type": "event2"
        }
    },
    "mutation_type": "insert",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "44f6137c-df69-417a-846d-777a26b14cfe",
    "mutation_time_ms": 1712005708000
}
{
    "data":
    {
        "current_version":
        {
            "insert_id": 1,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 11,
            "event_type": "event1"
        }
    },
    "mutation_type": "insert",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "3383b44f-b8a3-4b59-9d05-8bb765b99dc6",
    "mutation_time_ms": 1712005708000
}
{
    "data":
    {
        "current_version":
        {
            "insert_id": 2,
            "time": "2024-04-01T21:08:26.823Z",
            "user_id": 12,
            "event_type": "event2"
        }
    },
    "mutation_type": "delete",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "06a17d9b-1902-4144-ad15-df5a38c426bc",
    "mutation_time_ms": 1712005737000
}
```

</p>
</details> 

- [x] Manual testing through DataBricks DatabricksToS3WorkerServiceIntegrationTest.testUnloadData

Testing Output Example
<details><summary>Initial Sync</summary>
<p>

```
{
    "data":
    {
        "current_version":
        {
            "time": 1712167317509,
            "user_id": 12,
            "event_type": "databricks_import_canary_test_event",
            "user_properties":
            {
                "name": "NY",
                "home": "Micheal3",
                "age": 20,
                "income": 6000000
            },
            "groups":
            {
                "group_type1":
                [
                    "group_A",
                    "group_B"
                ]
            },
            "group_properties":
            {
                "group_property": "group_property_value"
            }
        }
    },
    "mutation_type": "insert",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "94d8a28b-f020-41de-bebc-b27064d16332",
    "mutation_time_ms": 1712167317000
}
```

</p>
</details> 

<details><summary>Continuous Sync</summary>
<p>

```
{
    "data":
    {
        "current_version":
        {
            "time": 1712168462134,
            "user_id": 12,
            "insert_id": 12,
            "event_type": "databricks_import_canary_test_event",
            "user_properties":
            {
                "name": "NY",
                "home": "Micheal3",
                "age": 20,
                "income": 6000000
            },
            "groups":
            {
                "group_type1":
                [
                    "group_A",
                    "group_B"
                ]
            },
            "group_properties":
            {
                "group_property": "group_property_value"
            }
        },
        "previous_version":
        {
            "time": 1712168462134,
            "user_id": 12,
            "insert_id": 12,
            "event_type": "databricks_import_canary_test_event",
            "user_properties":
            {
                "name": "NY",
                "home": "Micheal2",
                "age": 20,
                "income": 6000000
            },
            "groups":
            {
                "group_type1":
                [
                    "group_A",
                    "group_B"
                ]
            },
            "group_properties":
            {
                "group_property": "group_property_value"
            }
        }
    },
    "mutation_type": "update",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "90382a6d-cda4-4c3c-bdf3-25c0257e09bb",
    "mutation_time_ms": 1695257143000
}
{
    "data":
    {
        "current_version":
        {
            "time": 1712168462134,
            "user_id": 12,
            "insert_id": 12,
            "event_type": "databricks_import_canary_test_event",
            "user_properties":
            {
                "name": "NY",
                "home": "Micheal",
                "age": 20,
                "income": 6000000
            },
            "groups":
            {
                "group_type1":
                [
                    "group_A",
                    "group_B"
                ]
            },
            "group_properties":
            {
                "group_property": "group_property_value"
            }
        }
    },
    "mutation_type": "delete",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "d4bc55a3-d4a8-49fe-85f3-1f0c4a178b26",
    "mutation_time_ms": 1695257063000
}
{
    "data":
    {
        "current_version":
        {
            "time": 1712168462134,
            "user_id": 12,
            "insert_id": 12,
            "event_type": "databricks_import_canary_test_event",
            "user_properties":
            {
                "name": "NY",
                "home": "Micheal2",
                "age": 20,
                "income": 6000000
            },
            "groups":
            {
                "group_type1":
                [
                    "group_A",
                    "group_B"
                ]
            },
            "group_properties":
            {
                "group_property": "group_property_value"
            }
        }
    },
    "mutation_type": "insert",
    "data_type": "http_api_event_json",
    "mutation_insert_id": "aeffea3e-1184-4d99-a0aa-44900fca3509",
    "mutation_time_ms": 1695257088000
}
```

</p>
</details> 