### PR TITLE
AMP-97432 don't stop spark session

### DIFF
--- a/unload_databricks_data_to_s3.py
+++ b/unload_databricks_data_to_s3.py
@@ -153,4 +153,4 @@ if __name__ == '__main__':
     try:
         spark.stop()
     except BaseException as error:
-        print("An error happened when stopping spark session. Error {}", error)
+        print("An error happened when stopping spark session. Error: {}", error)

--- a/unload_databricks_data_to_s3.py
+++ b/unload_databricks_data_to_s3.py
@@ -152,5 +152,5 @@ if __name__ == '__main__':
     # stop spark session
     try:
         spark.stop()
-    except:
-        print("An error happened when stopping spark session")
+    except BaseException as error:
+        print("An error happened when stopping spark session. Error {}", error)

--- a/unload_databricks_data_to_s3.py
+++ b/unload_databricks_data_to_s3.py
@@ -149,8 +149,3 @@ if __name__ == '__main__':
         print("Unloaded {event_count} events.".format(event_count=event_count))
     else:
         print("No events were exported.")
-    # stop spark session
-    try:
-        spark.stop()
-    except BaseException as error:
-        print("An error happened when stopping spark session. Error: {}", error)


### PR DESCRIPTION
According to https://community.databricks.com/t5/data-engineering/few-things-you-should-not-do-in-databricks/m-p/20866#M14127, we shouldn't run `spark.stop` as databricks will manage the cluster for us. This will avoid a bunch of issues that seen by collectiveHealth when closing spark session.