### PR TITLE
DWH-620 [databricks-import] Fix SQL corruption when one source table name is a substring of another

### DIFF
--- a/TEST_unload_databricks_data_to_s3.py
+++ b/TEST_unload_databricks_data_to_s3.py
@@ -9,6 +9,7 @@ import argparse
 import collections
 import json
 import math
+import re
 import uuid
 import time
 from typing import Optional
@@ -260,6 +261,35 @@ def export_meta_data(event_count: int, partition_count: int):
 
 
 
+# Characters that are valid inside a (possibly backtick-quoted, fully-qualified)
+# SQL identifier. If a match is preceded or followed by one of these, it is part
+# of a longer identifier and must NOT be replaced.
+_IDENTIFIER_CHAR = r"[A-Za-z0-9_.`]"
+
+
+def replace_table_name_in_sql(sql: str, table_name: str, replacement: str) -> str:
+    """
+    Replace whole-identifier occurrences of a fully-qualified table name in SQL
+    with a replacement (temp view) name.
+
+    A naive ``sql.replace(table_name, replacement)`` is unsafe when one source
+    table name is a substring of another. For example ``cat.sch.dim_product`` is
+    contained in ``cat.sch.dim_product_version_map``, so replacing the shorter
+    name also rewrites the middle of the longer reference, producing invalid SQL
+    that Databricks rejects with ``PARSE_SYNTAX_ERROR ... at or near 'AS'``.
+
+    We only replace matches that are not adjacent to another identifier character
+    (alphanumerics, ``_``, ``.`` or a backtick), so a table name is never spliced
+    into the middle of a longer table name.
+    """
+    pattern = re.compile(
+        r"(?<!" + _IDENTIFIER_CHAR + r")"
+        + re.escape(table_name)
+        + r"(?!" + _IDENTIFIER_CHAR + r")"
+    )
+    return pattern.sub(lambda _match: replacement, sql)
+
+
 def build_views_for_tables(
         original_sql: str,
         table_to_import_version_range_map: dict[str, list[int]],
@@ -316,7 +346,7 @@ def build_views_for_tables(
             table_results[table]["finalStartVersion"] = ending_version
             table_results[table]["finalEndVersion"] = ending_version
             view_name = _fetch_and_create_view(ending_version, ending_version)
-            sql_local = sql_local.replace(table, view_name)
+            sql_local = replace_table_name_in_sql(sql_local, table, view_name)
             log_info(f"Forced latest-only read for {table} at version {ending_version}.")
             continue
 
@@ -326,7 +356,7 @@ def build_views_for_tables(
         # handled by the higher-level catch during the write phase.
         try:
             view_name = _fetch_and_create_view(starting_version, ending_version)
-            sql_local = sql_local.replace(table, view_name)
+            sql_local = replace_table_name_in_sql(sql_local, table, view_name)
         except Exception as fetch_error:
             fallback_signature = extract_missing_cdf_error_signature(fetch_error)
             if fallback_signature is None:
@@ -341,7 +371,7 @@ def build_views_for_tables(
             table_results[table]["finalEndVersion"] = ending_version
 
             view_name = _fetch_and_create_view(ending_version, ending_version)
-            sql_local = sql_local.replace(table, view_name)
+            sql_local = replace_table_name_in_sql(sql_local, table, view_name)
             log_info(f"Successfully read {table} at version {ending_version}.")
 
     return sql_local

--- a/TEST_unload_databricks_data_to_s3.py
+++ b/TEST_unload_databricks_data_to_s3.py
@@ -261,10 +261,13 @@ def export_meta_data(event_count: int, partition_count: int):
 
 
 
-# Characters that are valid inside a (possibly backtick-quoted, fully-qualified)
-# SQL identifier. If a match is preceded or followed by one of these, it is part
-# of a longer identifier and must NOT be replaced.
-_IDENTIFIER_CHAR = r"[A-Za-z0-9_.`]"
+# Characters that are part of a single SQL identifier token (a backtick-quoted
+# name counts). A match adjacent to one of these is part of a longer identifier
+# and must NOT be replaced. '.' is intentionally excluded so a fully-qualified
+# name used as a column prefix (`cat.sch.t.col`) is still rewritten to the view,
+# while substring collisions (e.g. dim_product vs dim_product_version_map) are
+# still blocked by the alphanumeric/underscore boundary.
+_IDENTIFIER_CHAR = r"[A-Za-z0-9_`]"
 
 
 def replace_table_name_in_sql(sql: str, table_name: str, replacement: str) -> str:
@@ -279,8 +282,10 @@ def replace_table_name_in_sql(sql: str, table_name: str, replacement: str) -> st
     that Databricks rejects with ``PARSE_SYNTAX_ERROR ... at or near 'AS'``.
 
     We only replace matches that are not adjacent to another identifier character
-    (alphanumerics, ``_``, ``.`` or a backtick), so a table name is never spliced
-    into the middle of a longer table name.
+    (alphanumerics, ``_`` or a backtick), so a table name is never spliced into
+    the middle of a longer table name. ``.`` is deliberately not treated as an
+    identifier boundary, so a fully-qualified name used as a column prefix
+    (``cat.sch.t.col``) is rewritten to the view as well.
     """
     pattern = re.compile(
         r"(?<!" + _IDENTIFIER_CHAR + r")"

--- a/TEST_unload_databricks_data_to_s3.py
+++ b/TEST_unload_databricks_data_to_s3.py
@@ -377,6 +377,26 @@ def build_views_for_tables(
     return sql_local
 
 
+def build_export_dataframe(sql_to_run: str) -> DataFrame:
+    """
+    Run the transformed SQL and return the export DataFrame.
+
+    The transformed SQL has each source table swapped for a temp view, so it
+    differs from the customer's original query and is not otherwise recoverable
+    from the run logs. If Spark rejects it (e.g. a parse/analysis error), log the
+    exact SQL submitted so the failure can be root-caused directly. The original
+    exception is re-raised unchanged so existing retry/error handling is intact.
+    """
+    try:
+        return spark.sql(sql_to_run)
+    except Exception:
+        log_info(
+            "Failed to build DataFrame from transformed SQL. "
+            f"SQL submitted to Spark:\n{sql_to_run}"
+        )
+        raise
+
+
 def write_export_data_for_versions(
         original_sql: str,
         table_to_import_version_range_map: dict[str, list[int]],
@@ -405,7 +425,7 @@ def write_export_data_for_versions(
 
     # Create export DataFrame (deferred execution)
     log_info("Creating DataFrame with SQL transformation (execution deferred)")
-    export_data: DataFrame = spark.sql(sql_to_run)
+    export_data: DataFrame = build_export_dataframe(sql_to_run)
 
     # Validate max_records_per_file for any partitioning strategy
     if args.partitioning_strategy != 'none' and args.max_records_per_file <= 0:

--- a/test/test_export_dataframe_logging.py
+++ b/test/test_export_dataframe_logging.py
@@ -1,0 +1,96 @@
+import os
+import sys
+import types
+import unittest
+
+# unload_databricks_data_to_s3 imports pyspark at module load time, but the
+# behaviour under test (logging the transformed SQL on failure) does not need a
+# real Spark session — we inject a fake one. Stub pyspark so the module imports
+# without a local Spark install.
+def _install_pyspark_stub() -> None:
+    if "pyspark" in sys.modules:
+        return
+    pyspark = types.ModuleType("pyspark")
+    sql = types.ModuleType("pyspark.sql")
+    functions = types.ModuleType("pyspark.sql.functions")
+    sqltypes = types.ModuleType("pyspark.sql.types")
+
+    sql.SparkSession = object
+    sql.DataFrame = object
+    sql.Column = object
+    functions.col = lambda *a, **k: None
+    sql.functions = functions
+    for name in ("StructType", "ArrayType", "MapType", "NullType", "DataType"):
+        setattr(sqltypes, name, type(name, (), {}))
+
+    pyspark.sql = sql
+    sys.modules["pyspark"] = pyspark
+    sys.modules["pyspark.sql"] = sql
+    sys.modules["pyspark.sql.functions"] = functions
+    sys.modules["pyspark.sql.types"] = sqltypes
+
+
+_install_pyspark_stub()
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import unload_databricks_data_to_s3 as mod
+
+
+class _FakeSparkRaises:
+    """Spark double whose sql() rejects the query, like a PARSE_SYNTAX_ERROR."""
+
+    def __init__(self, error: Exception):
+        self.error = error
+
+    def sql(self, query):
+        raise self.error
+
+
+class _FakeSparkReturns:
+    """Spark double whose sql() returns a sentinel DataFrame."""
+
+    def __init__(self, dataframe):
+        self.dataframe = dataframe
+
+    def sql(self, query):
+        return self.dataframe
+
+
+class TestBuildExportDataframeLogging(unittest.TestCase):
+
+    def setUp(self):
+        self._orig_spark = getattr(mod, "spark", None)
+        mod.LOG_MESSAGES.clear()
+
+    def tearDown(self):
+        mod.spark = self._orig_spark
+
+    def test_logs_transformed_sql_when_spark_rejects_it(self):
+        # The transformed SQL (source tables swapped for temp views) is what
+        # Spark parses and differs from the customer's original query; on a
+        # parse/analysis failure it must be logged so the failure can be
+        # root-caused without re-deriving the rewrite.
+        transformed_sql = "SELECT * FROM `cat.sch.t.123` AS f JOIN `cat.sch.u.456` AS u"
+        error = ValueError("[PARSE_SYNTAX_ERROR] Syntax error at or near 'AS'.")
+        mod.spark = _FakeSparkRaises(error)
+
+        with self.assertRaises(ValueError):
+            mod.build_export_dataframe(transformed_sql)
+
+        logged = "\n".join(mod.LOG_MESSAGES)
+        self.assertIn(transformed_sql, logged)
+
+    def test_returns_dataframe_and_does_not_log_failure_on_success(self):
+        sentinel = object()
+        mod.spark = _FakeSparkReturns(sentinel)
+
+        result = mod.build_export_dataframe("SELECT 1")
+
+        self.assertIs(result, sentinel)
+        self.assertFalse(
+            any("Failed to build DataFrame" in message for message in mod.LOG_MESSAGES)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_table_name_substitution.py
+++ b/test/test_table_name_substitution.py
@@ -93,6 +93,22 @@ class TestReplaceTableNameInSql(unittest.TestCase):
                     result,
                 )
 
+    def test_rewrites_table_name_used_as_a_qualified_column_prefix(self):
+        # A fully-qualified table name can also appear as a column qualifier
+        # (e.g. `cat.sch.t.col`). That prefix refers to the same table and must
+        # be rewritten to the temp view too, otherwise the SELECT list points at
+        # the original table while the FROM points at the view. The '.' before
+        # `col` must NOT block the match (it is a separator, not part of the
+        # table identifier).
+        for module_name, replace_table_name_in_sql in _helpers():
+            with self.subTest(module=module_name):
+                sql = "SELECT cat.sch.t.col FROM cat.sch.t"
+                result = replace_table_name_in_sql(sql, "cat.sch.t", "`cat.sch.t.42`")
+                self.assertEqual(
+                    "SELECT `cat.sch.t.42`.col FROM `cat.sch.t.42`",
+                    result,
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_table_name_substitution.py
+++ b/test/test_table_name_substitution.py
@@ -1,0 +1,98 @@
+import os
+import sys
+import types
+import unittest
+
+# unload_databricks_data_to_s3 imports pyspark at module load time, but the
+# table-name substitution logic under test is pure string manipulation with no
+# Spark dependency. Stub the pyspark modules so the module can be imported and
+# the helper exercised without a local Spark install.
+def _install_pyspark_stub() -> None:
+    if "pyspark" in sys.modules:
+        return
+    pyspark = types.ModuleType("pyspark")
+    sql = types.ModuleType("pyspark.sql")
+    functions = types.ModuleType("pyspark.sql.functions")
+    sqltypes = types.ModuleType("pyspark.sql.types")
+
+    sql.SparkSession = object
+    sql.DataFrame = object
+    sql.Column = object
+    functions.col = lambda *a, **k: None
+    sql.functions = functions
+    for name in ("StructType", "ArrayType", "MapType", "NullType", "DataType"):
+        setattr(sqltypes, name, type(name, (), {}))
+
+    pyspark.sql = sql
+    sys.modules["pyspark"] = pyspark
+    sys.modules["pyspark.sql"] = sql
+    sys.modules["pyspark.sql.functions"] = functions
+    sys.modules["pyspark.sql.types"] = sqltypes
+
+
+_install_pyspark_stub()
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import importlib
+
+# Every standalone unload script carries its own copy of the substitution helper
+# (each is uploaded to and executed on Databricks independently), so the fix must
+# hold in all of them.
+_MODULES_UNDER_TEST = (
+    "unload_databricks_data_to_s3",
+    "unload_databricks_data_to_s3_partition",
+    "TEST_unload_databricks_data_to_s3",
+)
+
+
+def _helpers():
+    for module_name in _MODULES_UNDER_TEST:
+        module = importlib.import_module(module_name)
+        yield module_name, module.replace_table_name_in_sql
+
+
+class TestReplaceTableNameInSql(unittest.TestCase):
+
+    def test_replaces_a_standalone_table_reference(self):
+        for module_name, replace_table_name_in_sql in _helpers():
+            with self.subTest(module=module_name):
+                sql = "FROM cat.sch.dim_product AS dp"
+                result = replace_table_name_in_sql(
+                    sql, "cat.sch.dim_product", "`cat.sch.dim_product.1700000000`"
+                )
+                self.assertEqual("FROM `cat.sch.dim_product.1700000000` AS dp", result)
+
+    def test_does_not_corrupt_table_name_that_contains_the_target_as_a_prefix(self):
+        # 'cat.sch.dim_product' is a substring of 'cat.sch.dim_product_version_map'.
+        # Replacing the shorter name must leave the longer reference untouched,
+        # otherwise the generated SQL becomes
+        #   `cat.sch.dim_product.1700000000`_version_map AS dpvm
+        # which Databricks rejects with PARSE_SYNTAX_ERROR at or near 'AS'.
+        for module_name, replace_table_name_in_sql in _helpers():
+            with self.subTest(module=module_name):
+                sql = (
+                    "FROM cat.sch.dim_product AS dp\n"
+                    "LEFT JOIN cat.sch.dim_product_version_map AS dpvm ON dp.id = dpvm.id"
+                )
+                result = replace_table_name_in_sql(
+                    sql, "cat.sch.dim_product", "`cat.sch.dim_product.1700000000`"
+                )
+                self.assertEqual(
+                    "FROM `cat.sch.dim_product.1700000000` AS dp\n"
+                    "LEFT JOIN cat.sch.dim_product_version_map AS dpvm ON dp.id = dpvm.id",
+                    result,
+                )
+
+    def test_replaces_every_standalone_occurrence(self):
+        for module_name, replace_table_name_in_sql in _helpers():
+            with self.subTest(module=module_name):
+                sql = "SELECT * FROM cat.sch.t WHERE EXISTS (SELECT 1 FROM cat.sch.t)"
+                result = replace_table_name_in_sql(sql, "cat.sch.t", "`cat.sch.t.42`")
+                self.assertEqual(
+                    "SELECT * FROM `cat.sch.t.42` WHERE EXISTS (SELECT 1 FROM `cat.sch.t.42`)",
+                    result,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unload_databricks_data_to_s3.py
+++ b/unload_databricks_data_to_s3.py
@@ -254,10 +254,13 @@ def export_meta_data(event_count: int, partition_count: int):
 
 
 
-# Characters that are valid inside a (possibly backtick-quoted, fully-qualified)
-# SQL identifier. If a match is preceded or followed by one of these, it is part
-# of a longer identifier and must NOT be replaced.
-_IDENTIFIER_CHAR = r"[A-Za-z0-9_.`]"
+# Characters that are part of a single SQL identifier token (a backtick-quoted
+# name counts). A match adjacent to one of these is part of a longer identifier
+# and must NOT be replaced. '.' is intentionally excluded so a fully-qualified
+# name used as a column prefix (`cat.sch.t.col`) is still rewritten to the view,
+# while substring collisions (e.g. dim_product vs dim_product_version_map) are
+# still blocked by the alphanumeric/underscore boundary.
+_IDENTIFIER_CHAR = r"[A-Za-z0-9_`]"
 
 
 def replace_table_name_in_sql(sql: str, table_name: str, replacement: str) -> str:
@@ -274,8 +277,10 @@ def replace_table_name_in_sql(sql: str, table_name: str, replacement: str) -> st
     rejects with ``PARSE_SYNTAX_ERROR ... at or near 'AS'``.
 
     We therefore only replace matches that are not adjacent to another identifier
-    character (alphanumerics, ``_``, ``.`` or a backtick), so a table name is
-    never spliced into the middle of a longer table name.
+    character (alphanumerics, ``_`` or a backtick), so a table name is never
+    spliced into the middle of a longer table name. ``.`` is deliberately not
+    treated as an identifier boundary, so a fully-qualified name used as a column
+    prefix (``cat.sch.t.col``) is rewritten to the view as well.
     """
     pattern = re.compile(
         r"(?<!" + _IDENTIFIER_CHAR + r")"

--- a/unload_databricks_data_to_s3.py
+++ b/unload_databricks_data_to_s3.py
@@ -374,6 +374,26 @@ def build_views_for_tables(
     return sql_local
 
 
+def build_export_dataframe(sql_to_run: str) -> DataFrame:
+    """
+    Run the transformed SQL and return the export DataFrame.
+
+    The transformed SQL has each source table swapped for a temp view, so it
+    differs from the customer's original query and is not otherwise recoverable
+    from the run logs. If Spark rejects it (e.g. a parse/analysis error), log the
+    exact SQL submitted so the failure can be root-caused directly. The original
+    exception is re-raised unchanged so existing retry/error handling is intact.
+    """
+    try:
+        return spark.sql(sql_to_run)
+    except Exception:
+        log_info(
+            "Failed to build DataFrame from transformed SQL. "
+            f"SQL submitted to Spark:\n{sql_to_run}"
+        )
+        raise
+
+
 def write_export_data_for_versions(
         original_sql: str,
         table_to_import_version_range_map: dict[str, list[int]],
@@ -402,7 +422,7 @@ def write_export_data_for_versions(
 
     # Create export DataFrame (deferred execution)
     log_info("Creating DataFrame with SQL transformation (execution deferred)")
-    export_data: DataFrame = spark.sql(sql_to_run)
+    export_data: DataFrame = build_export_dataframe(sql_to_run)
 
     # Validate max_records_per_file for any partitioning strategy
     if args.partitioning_strategy != 'none' and args.max_records_per_file <= 0:

--- a/unload_databricks_data_to_s3.py
+++ b/unload_databricks_data_to_s3.py
@@ -2,6 +2,7 @@ import argparse
 import collections
 import json
 import math
+import re
 import uuid
 import time
 from typing import Optional
@@ -253,6 +254,39 @@ def export_meta_data(event_count: int, partition_count: int):
 
 
 
+# Characters that are valid inside a (possibly backtick-quoted, fully-qualified)
+# SQL identifier. If a match is preceded or followed by one of these, it is part
+# of a longer identifier and must NOT be replaced.
+_IDENTIFIER_CHAR = r"[A-Za-z0-9_.`]"
+
+
+def replace_table_name_in_sql(sql: str, table_name: str, replacement: str) -> str:
+    """
+    Replace whole-identifier occurrences of a fully-qualified table name in SQL
+    with a replacement (temp view) name.
+
+    A naive ``sql.replace(table_name, replacement)`` is unsafe when one source
+    table name is a substring of another. For example
+    ``cat.sch.dim_product`` is contained in ``cat.sch.dim_product_version_map``,
+    so replacing the shorter name also rewrites the middle of the longer
+    reference, producing invalid SQL such as
+    ``\\`cat.sch.dim_product.<epoch>\\`_version_map AS dpvm`` which Databricks
+    rejects with ``PARSE_SYNTAX_ERROR ... at or near 'AS'``.
+
+    We therefore only replace matches that are not adjacent to another identifier
+    character (alphanumerics, ``_``, ``.`` or a backtick), so a table name is
+    never spliced into the middle of a longer table name.
+    """
+    pattern = re.compile(
+        r"(?<!" + _IDENTIFIER_CHAR + r")"
+        + re.escape(table_name)
+        + r"(?!" + _IDENTIFIER_CHAR + r")"
+    )
+    # Use a function replacement so backslashes / group references in the view
+    # name are inserted literally rather than interpreted by re.sub.
+    return pattern.sub(lambda _match: replacement, sql)
+
+
 def build_views_for_tables(
         original_sql: str,
         table_to_import_version_range_map: dict[str, list[int]],
@@ -309,7 +343,7 @@ def build_views_for_tables(
             table_results[table]["finalStartVersion"] = ending_version
             table_results[table]["finalEndVersion"] = ending_version
             view_name = _fetch_and_create_view(ending_version, ending_version)
-            sql_local = sql_local.replace(table, view_name)
+            sql_local = replace_table_name_in_sql(sql_local, table, view_name)
             log_info(f"Forced latest-only read for {table} at version {ending_version}.")
             continue
 
@@ -319,7 +353,7 @@ def build_views_for_tables(
         # handled by the higher-level catch during the write phase.
         try:
             view_name = _fetch_and_create_view(starting_version, ending_version)
-            sql_local = sql_local.replace(table, view_name)
+            sql_local = replace_table_name_in_sql(sql_local, table, view_name)
         except Exception as fetch_error:
             fallback_signature = extract_missing_cdf_error_signature(fetch_error)
             if fallback_signature is None:
@@ -334,7 +368,7 @@ def build_views_for_tables(
             table_results[table]["finalEndVersion"] = ending_version
 
             view_name = _fetch_and_create_view(ending_version, ending_version)
-            sql_local = sql_local.replace(table, view_name)
+            sql_local = replace_table_name_in_sql(sql_local, table, view_name)
             log_info(f"Successfully read {table} at version {ending_version}.")
 
     return sql_local

--- a/unload_databricks_data_to_s3_partition.py
+++ b/unload_databricks_data_to_s3_partition.py
@@ -174,8 +174,15 @@ if __name__ == '__main__':
         # replace table name in sql to get prepared for sql transformation
         sql = replace_table_name_in_sql(sql, table, view_name)
 
-    # run SQL to transform data
-    export_data: DataFrame = spark.sql(sql)
+    # run SQL to transform data. The transformed SQL has each source table
+    # swapped for a temp view, so it differs from the customer's original query;
+    # log the exact SQL if Spark rejects it (e.g. a parse error) so the failure
+    # can be root-caused, then re-raise unchanged.
+    try:
+        export_data: DataFrame = spark.sql(sql)
+    except Exception:
+        print("Failed to build DataFrame from transformed SQL. SQL submitted to Spark:\n{sql}".format(sql=sql))
+        raise
 
     num_partitions = math.ceil(export_data.count() / args.max_records_per_file)
 

--- a/unload_databricks_data_to_s3_partition.py
+++ b/unload_databricks_data_to_s3_partition.py
@@ -42,10 +42,13 @@ def build_temp_view_name(table_full_name: str) -> str:
     return '`{table}.{epoch}`'.format(table=table_full_name, epoch=int(time.time()))
 
 
-# Characters that are valid inside a (possibly backtick-quoted, fully-qualified)
-# SQL identifier. If a match is preceded or followed by one of these, it is part
-# of a longer identifier and must NOT be replaced.
-_IDENTIFIER_CHAR = r"[A-Za-z0-9_.`]"
+# Characters that are part of a single SQL identifier token (a backtick-quoted
+# name counts). A match adjacent to one of these is part of a longer identifier
+# and must NOT be replaced. '.' is intentionally excluded so a fully-qualified
+# name used as a column prefix (`cat.sch.t.col`) is still rewritten to the view,
+# while substring collisions (e.g. dim_product vs dim_product_version_map) are
+# still blocked by the alphanumeric/underscore boundary.
+_IDENTIFIER_CHAR = r"[A-Za-z0-9_`]"
 
 
 def replace_table_name_in_sql(sql: str, table_name: str, replacement: str) -> str:
@@ -60,8 +63,10 @@ def replace_table_name_in_sql(sql: str, table_name: str, replacement: str) -> st
     that Databricks rejects with ``PARSE_SYNTAX_ERROR ... at or near 'AS'``.
 
     We only replace matches that are not adjacent to another identifier character
-    (alphanumerics, ``_``, ``.`` or a backtick), so a table name is never spliced
-    into the middle of a longer table name.
+    (alphanumerics, ``_`` or a backtick), so a table name is never spliced into
+    the middle of a longer table name. ``.`` is deliberately not treated as an
+    identifier boundary, so a fully-qualified name used as a column prefix
+    (``cat.sch.t.col``) is rewritten to the view as well.
     """
     pattern = re.compile(
         r"(?<!" + _IDENTIFIER_CHAR + r")"

--- a/unload_databricks_data_to_s3_partition.py
+++ b/unload_databricks_data_to_s3_partition.py
@@ -1,6 +1,7 @@
 import argparse
 import collections
 import math
+import re
 import time
 
 from pyspark.sql import SparkSession
@@ -39,6 +40,35 @@ def build_temp_view_name(table_full_name: str) -> str:
     :return: temp view name for the table
     """
     return '`{table}.{epoch}`'.format(table=table_full_name, epoch=int(time.time()))
+
+
+# Characters that are valid inside a (possibly backtick-quoted, fully-qualified)
+# SQL identifier. If a match is preceded or followed by one of these, it is part
+# of a longer identifier and must NOT be replaced.
+_IDENTIFIER_CHAR = r"[A-Za-z0-9_.`]"
+
+
+def replace_table_name_in_sql(sql: str, table_name: str, replacement: str) -> str:
+    """
+    Replace whole-identifier occurrences of a fully-qualified table name in SQL
+    with a replacement (temp view) name.
+
+    A naive ``sql.replace(table_name, replacement)`` is unsafe when one source
+    table name is a substring of another. For example ``cat.sch.dim_product`` is
+    contained in ``cat.sch.dim_product_version_map``, so replacing the shorter
+    name also rewrites the middle of the longer reference, producing invalid SQL
+    that Databricks rejects with ``PARSE_SYNTAX_ERROR ... at or near 'AS'``.
+
+    We only replace matches that are not adjacent to another identifier character
+    (alphanumerics, ``_``, ``.`` or a backtick), so a table name is never spliced
+    into the middle of a longer table name.
+    """
+    pattern = re.compile(
+        r"(?<!" + _IDENTIFIER_CHAR + r")"
+        + re.escape(table_name)
+        + r"(?!" + _IDENTIFIER_CHAR + r")"
+    )
+    return pattern.sub(lambda _match: replacement, sql)
 
 
 def build_sql_to_query_table_of_version(table_full_name: str, ending_version: int) -> str:
@@ -142,7 +172,7 @@ if __name__ == '__main__':
         view_name: str = build_temp_view_name(table)
         data.createOrReplaceTempView(view_name)
         # replace table name in sql to get prepared for sql transformation
-        sql = sql.replace(table, view_name)
+        sql = replace_table_name_in_sql(sql, table, view_name)
 
     # run SQL to transform data
     export_data: DataFrame = spark.sql(sql)


### PR DESCRIPTION
## Problem

Databricks warehouse imports fail with `PARSE_SYNTAX_ERROR ... at or near 'AS'. SQLSTATE: 42601` when the import query joins two source tables where one table's fully-qualified name is a **substring** of the other (e.g. `cat.sch.dim_product` ⊂ `cat.sch.dim_product_version_map`).

For incremental (`CONTINUOUS`/CDC) imports, the unload script reads each source table via `table_changes(...)`, registers a temp view, and swaps the table name in the customer's SQL for the view name with a naive `sql.replace(table, view_name)`. Because that has no token/word boundaries, replacing the shorter name also rewrites the substring inside the longer reference:

```
LEFT JOIN cat.sch.dim_product_version_map AS dpvm
-->  LEFT JOIN `cat.sch.dim_product.<epoch>`_version_map AS dpvm
```

Databricks parses `` `…dim_product.<epoch>` `` as the table identifier, takes `_version_map` as an implicit alias, then errors on the following `AS`. Order-independent: whichever table is substituted first, the other reference (or the already-substituted view name) gets mangled. The customer's SQL is valid and runs fine in a notebook — only our rewrite breaks it.

## Fix

Boundary-aware `replace_table_name_in_sql()` that only substitutes a table name when it is **not** adjacent to another identifier character (`[A-Za-z0-9_.``]`). `.` and `_` are identifier chars, so a plain `\b` regex wouldn't work, and length-ordering alone wouldn't either (the short name is a substring of the substituted view name too).

Applied to all three scripts that carried the bug:
- `unload_databricks_data_to_s3.py` (production, 3 call sites)
- `unload_databricks_data_to_s3_partition.py` (partition variant, 1 call site)
- `TEST_unload_databricks_data_to_s3.py` (prototype that gets ported to main, 3 call sites)

Also adds `build_export_dataframe()` (and a `try/except` around the partition variant's inline `spark.sql`) to **log the transformed SQL when Spark rejects it**, then re-raise unchanged. The rewritten SQL differs from the customer's stored query and was previously unrecoverable from the logs, which is what made this bug slow to root-cause.

## Tests

`test/test_table_name_substitution.py` reproduces the substring collision across all three modules; `test/test_export_dataframe_logging.py` covers log-on-failure and pass-through-on-success. Both stub pyspark so the pure logic runs without a Spark install. Verified red→green.

```
python3 -m unittest test.test_table_name_substitution test.test_export_dataframe_logging   # OK (5 tests)
```

## Known limitations (intentionally out of scope)

This hardens the existing string-substitution approach; it fixes the substring collision (the recurring failure class) but is still text-pattern matching, so it does not cover every possible SQL:

- A fully-qualified table name appearing **inside a string literal or comment** would still be rewritten.
- **Per-part quoted** identifiers (`` `cat`.`sch`.`t` ``) or case/whitespace variants won't match (no substitution happens).

These are unlikely in real warehouse-import queries (table names live in `FROM`/`JOIN`, not string values), and a miss surfaces as a job error rather than silent bad data. Future hardening options if needed:
- **A.** Mask string literals/comments before substituting (no new deps).
- **B.** Parse with `sqlglot` and replace `Table` nodes by source position (do NOT re-render the whole query — this query uses `GETDATE()`/`MAP_CONCAT`/`try_cast`, which a dialect re-render could alter). Adds a cluster dependency.

## Deployment / rollout model

These scripts are **not** built or shipped as an artifact. Falcon configures each Databricks job with a GitHub `git_source` pinned to this repo's **`main`** branch plus a `SparkPythonTask` that runs the script by filename (in the `nova` monorepo):

- `DatabricksImportRequestHandler.java:241-243` and `DatabricksToS3WorkerJobExecutor.java:743-746 / 777-780`:
  `GitSource().setGitProvider(GIT_HUB).setGitUrl(".../databricks-import-pySpark-scripts").setGitBranch("main")`
- Script selection — `DatabricksToS3WorkerJobExecutor.java:119-120, 700-711`: prod = `unload_databricks_data_to_s3.py`; test = `TEST_unload_databricks_data_to_s3.py`, gated per-app by dynconf `falcon.databricksImport.useTestUnloadScript`.

Databricks resolves `main` to HEAD at the **start of every job run**, so:

- **Deploy = merge this PR to `main`.** The next run of every import pipeline checks out fresh `main` and uses the fixed script automatically.
- **No Falcon redeploy** and **no recreating existing Databricks jobs** — their stored `git_source` already tracks `main`.
- It is effectively an **immediate fleet-wide rollout** (branch is hardcoded, not gated), so validate promptly after merge.
- After merge, **re-trigger the affected pipeline** (e.g. `223678`, currently `DISCONNECTED` with `tries=13`) and confirm the `databricks_to_s3` worker succeeds — a pipeline that exhausted retries may need a manual re-enable/re-trigger.

## Context

- Linear: DWH-620
- Zendesk #397794 (org 39680677, app 790716); Falcon pipeline `source_destination_id 223678` has never had a successful run since 2026-05-30.

## Follow-ups (not in this PR)

- Re-categorize this failure away from `customer_error` (`databricks:customer_error_recoverable_does_page`) — it's an Amplitude-side defect.
- Consider validating source table-name collisions at pipeline-creation time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production Databricks import unload logic fleet-wide on merge to main, but the change is localized, well-tested, and preserves existing exception/retry behavior.
> 
> **Overview**
> Fixes Databricks warehouse import failures when a source table’s fully-qualified name is a **substring** of another table in the same query. The unload scripts used naive `sql.replace`, which corrupted longer table references (e.g. `dim_product` inside `dim_product_version_map`) and caused `PARSE_SYNTAX_ERROR` at `AS`.
> 
> **`replace_table_name_in_sql()`** substitutes table names only at identifier boundaries (regex lookaround on alphanumerics, `_`, and backticks—not `.`), so longer names stay intact while qualified column prefixes like `cat.sch.t.col` still rewrite to the temp view. Wired into **`build_views_for_tables`** in all three unload scripts (`unload_databricks_data_to_s3.py`, partition variant, and test script).
> 
> **`build_export_dataframe()`** (or equivalent try/except in the partition script) logs the **transformed** SQL when Spark rejects it, then re-raises—making parse failures debuggable without changing retry behavior.
> 
> New unit tests cover substring collisions across all three modules and failure logging on the main script (PySpark stubbed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4ef1de8f6beb21b97bfe482ce90fb999bdca3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->