### PR TITLE
Databricks CDF resilience: endVersion schema mode + incompatible-schema retry

### DIFF
--- a/test/test_schema_resilience.py
+++ b/test/test_schema_resilience.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import types
+import unittest
+
+
+def _install_pyspark_stub() -> None:
+    if "pyspark" in sys.modules:
+        return
+    pyspark = types.ModuleType("pyspark")
+    sql = types.ModuleType("pyspark.sql")
+    functions = types.ModuleType("pyspark.sql.functions")
+    sqltypes = types.ModuleType("pyspark.sql.types")
+
+    sql.SparkSession = object
+    sql.DataFrame = object
+    sql.Column = object
+    functions.col = lambda *a, **k: None
+    sql.functions = functions
+    for name in ("StructType", "ArrayType", "MapType", "NullType", "DataType"):
+        setattr(sqltypes, name, type(name, (), {}))
+
+    pyspark.sql = sql
+    sys.modules["pyspark"] = pyspark
+    sys.modules["pyspark.sql"] = sql
+    sys.modules["pyspark.sql.functions"] = functions
+    sys.modules["pyspark.sql.types"] = sqltypes
+
+
+_install_pyspark_stub()
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import unload_databricks_data_to_s3 as mod
+
+
+class TestIncompatibleSchemaSignature(unittest.TestCase):
+
+    def test_matches_incompatible_data_schema(self):
+        err = Exception(
+            "[DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA] Retrieving table "
+            "changes between version 31 and 53 failed because of an incompatible data schema."
+        )
+        self.assertEqual(
+            "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA",
+            mod.extract_incompatible_schema_error_signature(err),
+        )
+
+    def test_matches_incompatible_schema_change(self):
+        err = Exception("oops [DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_SCHEMA_CHANGE] column renamed")
+        self.assertEqual(
+            "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_SCHEMA_CHANGE",
+            mod.extract_incompatible_schema_error_signature(err),
+        )
+
+    def test_returns_none_for_unrelated_error(self):
+        self.assertIsNone(mod.extract_incompatible_schema_error_signature(Exception("network timeout")))
+
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(mod.extract_incompatible_schema_error_signature(None))

--- a/unload_databricks_data_to_s3.py
+++ b/unload_databricks_data_to_s3.py
@@ -24,6 +24,10 @@ MAX_RECORDS_PER_OUTPUT_FILE: int = 100_000
 
 MISSING_CDF_FILE_ERROR_SIGNATURE = "DELTA_CHANGE_DATA_FILE_NOT_FOUND"
 SPARK_DBR_FILE_NOT_EXIST_SIGNATURE = "FAILED_READ_FILE.DBR_FILE_NOT_EXIST"
+INCOMPATIBLE_SCHEMA_ERROR_SIGNATURES = (
+    "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA",
+    "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_SCHEMA_CHANGE",
+)
 
 LOG_MESSAGES: list[str] = []
 
@@ -86,6 +90,27 @@ def extract_missing_cdf_error_signature(error: Exception) -> Optional[str]:
         return MISSING_CDF_FILE_ERROR_SIGNATURE
     if SPARK_DBR_FILE_NOT_EXIST_SIGNATURE in message:
         return SPARK_DBR_FILE_NOT_EXIST_SIGNATURE
+    return None
+
+def extract_incompatible_schema_error_signature(error: Exception) -> Optional[str]:
+    """
+    Return a signature string if the exception indicates a Delta CDF incompatible
+    schema change across the requested [start, end] version range.
+
+    Databricks surfaces this under two codes depending on DBR/Delta version:
+      - DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA: broader incompatibility,
+        seen on DBR 15+ column-mapping tables (e.g. reading CDF from a checkpoint
+        whose schema differs from the current table schema).
+      - DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_SCHEMA_CHANGE: column-mapping renames.
+    Both are unrecoverable for the [start, end) range; the caller recovers by
+    re-reading the table at end-version only (latest-only).
+    """
+    message = str(error) if error else ""
+    if not message:
+        return None
+    for signature in INCOMPATIBLE_SCHEMA_ERROR_SIGNATURES:
+        if signature in message:
+            return signature
     return None
 
 def _drop_nulltype_fields(col: Column, dtype: DataType) -> Column:
@@ -360,12 +385,15 @@ def build_views_for_tables(
             view_name = _fetch_and_create_view(starting_version, ending_version)
             sql_local = replace_table_name_in_sql(sql_local, table, view_name)
         except Exception as fetch_error:
-            fallback_signature = extract_missing_cdf_error_signature(fetch_error)
+            fallback_signature = (
+                extract_missing_cdf_error_signature(fetch_error)
+                or extract_incompatible_schema_error_signature(fetch_error)
+            )
             if fallback_signature is None:
-                # propagate non-CDF errors
+                # propagate errors we cannot recover by reading latest-only
                 raise
             log_info(
-                f"Encountered missing CDF files for {table} (signature={fallback_signature}). "
+                f"Encountered recoverable CDF error for {table} (signature={fallback_signature}). "
                 f"Skipping versions {table_results[table]['initialStartVersion']}-{table_results[table]['initialEndVersion'] - 1} and re-reading at last known good version {ending_version}."
             )
             table_results[table]["initialFetchError"] = str(fetch_error)
@@ -521,6 +549,11 @@ if __name__ == '__main__':
     log_info("Starting Databricks unload job")
 
     spark = SparkSession.builder.getOrCreate()
+    # Read Delta Change Data Feed using the END-version schema when a column-mapping
+    # table's schema changed across the requested version range. Without this, CDF
+    # reads fail with DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA / _SCHEMA_CHANGE
+    # on otherwise-compatible (e.g. additive) schema changes.
+    spark.conf.set("spark.databricks.delta.changeDataFeed.defaultSchemaModeForColumnMappingTable", "endVersion")
     # setup s3 credentials for data export
     aws_access_key = dbutils.secrets.get(scope=args.secret_scope, key=args.secret_key_name_for_aws_access_key)
     aws_secret_key = dbutils.secrets.get(scope=args.secret_scope, key=args.secret_key_name_for_aws_secret_key)
@@ -551,12 +584,15 @@ if __name__ == '__main__':
             force_latest_only=False,
         )
     except Exception as e:
-        sig = extract_missing_cdf_error_signature(e)
+        sig = (
+            extract_missing_cdf_error_signature(e)
+            or extract_incompatible_schema_error_signature(e)
+        )
         if sig is None:
-            # non-CDF error: re-raise immediately
+            # error we cannot recover by reading latest-only: re-raise
             raise
         log_info(
-            f"Failed with CDF missing-file signature ({sig}). "
+            f"Failed with recoverable CDF signature ({sig}). "
             f"Retrying with latest-only (start=end=end_version) for all tables."
         )
         # If we get a CDF error, retry with only the latest version for all tables any exception should propagate

--- a/unload_databricks_data_to_s3.py
+++ b/unload_databricks_data_to_s3.py
@@ -92,18 +92,20 @@ def extract_missing_cdf_error_signature(error: Exception) -> Optional[str]:
         return SPARK_DBR_FILE_NOT_EXIST_SIGNATURE
     return None
 
-def extract_incompatible_schema_error_signature(error: Exception) -> Optional[str]:
+def extract_incompatible_schema_error_signature(error: Optional[BaseException]) -> Optional[str]:
     """
     Return a signature string if the exception indicates a Delta CDF incompatible
-    schema change across the requested [start, end] version range.
+    schema change between the requested starting and ending versions.
 
     Databricks surfaces this under two codes depending on DBR/Delta version:
       - DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA: broader incompatibility,
         seen on DBR 15+ column-mapping tables (e.g. reading CDF from a checkpoint
         whose schema differs from the current table schema).
       - DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_SCHEMA_CHANGE: column-mapping renames.
-    Both are unrecoverable for the [start, end) range; the caller recovers by
-    re-reading the table at end-version only (latest-only).
+    The change feed for that starting-to-ending span is unrecoverable; the caller
+    recovers by re-reading the table at the ending version only (latest-only).
+
+    Accepts None (returns None) so callers can pass an optional/absent error.
     """
     message = str(error) if error else ""
     if not message:

--- a/unload_databricks_data_to_s3_partition.py
+++ b/unload_databricks_data_to_s3_partition.py
@@ -154,6 +154,11 @@ if __name__ == '__main__':
     args, unknown = parser.parse_known_args()
 
     spark = SparkSession.builder.getOrCreate()
+    # Read Delta Change Data Feed using the END-version schema when a column-mapping
+    # table's schema changed across the requested version range. Without this, CDF
+    # reads fail with DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA / _SCHEMA_CHANGE
+    # on otherwise-compatible (e.g. additive) schema changes.
+    spark.conf.set("spark.databricks.delta.changeDataFeed.defaultSchemaModeForColumnMappingTable", "endVersion")
     # setup s3 credentials for data export
     aws_access_key = dbutils.secrets.get(scope=args.secret_scope, key=args.secret_key_name_for_aws_access_key)
     aws_secret_key = dbutils.secrets.get(scope=args.secret_scope, key=args.secret_key_name_for_aws_secret_key)


### PR DESCRIPTION
## Summary

Makes the Databricks unload resilient to Delta Change Data Feed (CDF) schema/version drift, which currently fails runs with `DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA` / `_SCHEMA_CHANGE` when a column-mapping table's schema changed across the requested version range.

- **Preventive** (both unload scripts): set `spark.databricks.delta.changeDataFeed.defaultSchemaModeForColumnMappingTable=endVersion` right after `SparkSession` creation, so CDF reads across a column-mapping schema change use the end-version schema — handles compatible/additive changes transparently, no customer cluster config needed.
- **Recovery** (`unload_databricks_data_to_s3.py` only): detect the two incompatible-schema error codes and re-read the offending table latest-only (`start=end=end_version`), reusing the existing missing-CDF fallback at both catch points. Trade-off (the changed-version range is skipped for that one table) is logged in `table_results.json`. The partition script has no fallback scaffolding and gets the preventive conf only.

## Testing

`python3 -m unittest test.test_schema_resilience` — 4 tests for the new `extract_incompatible_schema_error_signature` (both error codes, unrelated error, empty). Full suite green.

## Notes

- Independent of the companion PR `ning/databricks-query-validation-and-resilience` — disjoint edits to the unload scripts; the two merge cleanly in either order (verified).
- Mirrors the Falcon-side DWHO-3987 error classification, but implemented as actual Spark-side recovery rather than just labeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes data export behavior when CDF hits schema drift—latest-only fallback can skip incremental changes for affected tables, though that trade-off is intentional and logged.
> 
> **Overview**
> Hardens Databricks Delta CDF unloads when column-mapping tables drift across the requested version range.
> 
> **Preventive:** Both `unload_databricks_data_to_s3.py` and `unload_databricks_data_to_s3_partition.py` set `spark.databricks.delta.changeDataFeed.defaultSchemaModeForColumnMappingTable` to `endVersion` at startup so CDF reads can use the end-version schema on compatible/additive schema changes.
> 
> **Recovery (main unload only):** Adds `extract_incompatible_schema_error_signature` for `DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA` and `DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_SCHEMA_CHANGE`, wired into the existing per-table and job-level CDF fallback paths alongside missing-file detection. On match, the job re-reads at latest-only (`start=end=end_version`) and logs the skipped range in `table_results`; unrelated errors still fail fast.
> 
> **Tests:** New `test/test_schema_resilience.py` (PySpark stub) covers signature extraction for both error codes, unrelated errors, and empty input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5af413303cec3bc7eb43abe7a7ad7639c49da5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->